### PR TITLE
ユーザー詳細ページ

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,2 @@
+class UsersController < ApplicationController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,7 @@
 class UsersController < ApplicationController
+
+  def show
+    @user = User.find(params[:id])
+    @contents = @user.contents.order("created_at DESC")
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -3,7 +3,7 @@
 
 <% if user_signed_in? %>
   <div>
-    <%= link_to current_user.name, "#", class: :mypage__link %>
+    <%= link_to current_user.name, user_path(current_user.id), class: :mypage__link %>
   </div>
 <% end %>
 <p>Find me in app/views/contents/index.html.erb</p>
@@ -33,10 +33,10 @@
             <%=safe_join(content.overview.split("\n"),tag(:br))%>
           </p>
           <p class='content__user_name'>
-            <%= content.user.name %><br />
+            <%= link_to content.user.name, user_path(content.user.id) %><br />
           </p>
           <p class='content__user_occupation'>
-            <%= content.user.occupation %><br />
+            <%= link_to content.user.occupation, user_path(content.user.id) %><br />
           </p>
         </div>
         <% end %>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -9,7 +9,7 @@
       <div class="content__date">
         <%= l @content.created_at %>
       </div>
-      <%= link_to @content.user.name, "#", class: :content__user %>
+      <%= link_to @content.user.name, user_path(@content.user), class: :content__user %>
 
       <%if user_signed_in? && current_user.id == @content.user_id %>
         <div class="content__manage">
@@ -73,7 +73,7 @@
                   <%= safe_join(comment.text.split("\n"),tag(:br)) %>
                 </div>
                 <div class="comment__bottom">
-                  <div><%= link_to comment.user.name, "#", class: :comment_user %></div>
+                  <div><%= link_to comment.user.name, user_path(comment.user), class: :comment_user %></div>
                   <div><%= comment.created_at.strftime("%Y-%m-%d %H:%M:%S") %></div>
                 </div>
               </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,85 @@
+
+<%= link_to "トップページ", root_path %>
+
+<div class="main">
+  <div class="inner">
+    <div class="user__wrapper">
+      <h2 class="page-heading">
+        <%= @user.name + "さんの情報"%>
+      </h2>
+      <table class="table">
+        <tbody>
+          <tr>
+            <th class="table__col1">名前</th>
+            <td class="table__col2"><%= @user.name %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">所属</th>
+            <td class="table__col2"><%= @user.occupation %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">プロフィール</th>
+            <td class="table__col2"><%= @user.occupation %>
+          </tr>
+        </tbody>
+      </table>
+      
+      <div class="user__card">
+        <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+        <%# <%= render partial: 'prototypes/prototype', collection: @contents %>
+        <li class='list'>
+
+        <% if @user.contributor? && @contents.present? %>
+          
+          <h2 class="page-heading">
+            <%= @user.name + "さんの投稿コンテンツ"%>
+          </h2>
+
+          <% @contents.each do |content| %>
+            <li class='list'>
+            <%= link_to content_path(content.id) do %>
+              <div class='content__img'>
+                <% if content.video_content.present? %>
+                  <%= video_tag(content.video_content.url, :controls => true, width: "370px")  %>
+                <% else %>
+                  <div class="image__content" >
+                  <%= image_tag content.image_content.url, width: '370px' %>
+                  </div>
+                <% end %>
+              </div>
+              <div class='content__info'>
+                <h3 class='content__title'>
+                  <%= content.title %>
+                </h3>
+                <p class='content__overview'>
+                  <%=safe_join(content.overview.split("\n"),tag(:br))%>
+                </p>
+              </div>
+            <% end %>
+            </li>
+          <% end %>
+        <% elsif @user.contributor? %>
+          <h2 class='no__content'>投稿コンテンツはありません！</h2>
+        <% end %>
+
+        <% if current_user.nil? && @user.student? %>
+          <h2 class='student__from_logoutuser'>
+          <p>ログインしていないユーザーの方へ<br />学生のマイページは表示できません。</p>
+          <p>Without haste, but without rest.</p>
+          <p>We are shaped and fashioned by what we love.</p>
+          <p>Your life is worth much more than gold.</p>
+          </h2>
+        <% elsif @user.student? && current_user == @user %>
+          <h2 class='student__own_display'>お気に入りコンテンツ一覧</h2>
+        <% elsif @user.student? %>
+          <h2 class='student__from_students'>
+          <p>学生のマイページは表示できません。</p>
+          <p>There is always a better way.</p>
+          <p>If you can dream it, you can do it.</p>
+          </h2>
+        <% end %>
+        </li>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,25 @@
 ja:
+  date:
+    formats:
+      default: "%Y-%m-%d"
+      short: "%m-%d"
+      long: "%Y年%m月%d日(%a)"
+
+    day_names: [日曜日, 月曜日, 火曜日, 水曜日, 木曜日, 金曜日, 土曜日]
+    abbr_day_names: [日, 月, 火, 水, 木, 金, 土]
+
+    month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+    abbr_month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+
+    order:
+      - :year
+      - :month
+      - :day
+
   time:
     formats:
-      default: "%Y/%m/%d %H:%M:%S"
+      default: "%Y-%m-%d %H:%M:%S"
+      short: "%y-%m-%d %H:%M"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %Z"
+    am: "午前"
+    pm: "午後"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   resources :contents do
     resources :comments, only: :create
   end
+  resources :users, only: :show
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UsersHelper. For example:
+#
+# describe UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+
+end


### PR DESCRIPTION
# What
ユーザー詳細ページの表示機能実装

# Why
ユーザーの詳細ページを実装するため

## Gyazo
* Gyazo GIF
トップページにある自分の名前をクリックすると、自分の詳細ページへ遷移すること：https://gyazo.com/94bbbbcc12615c79c6c23572b3d99534
各コンテンツの投稿者の名前をクリックすると、投稿者の詳細ページへ遷移すること：https://gyazo.com/f4b2266954166bd15f24306e0aa9bc11
コンテンツ詳細ページの名前をクリックすると、投稿者の詳細ページへ遷移すること：https://gyazo.com/1c0db2a5a663dcab39e62393ecde9c25
コメントの投稿者の名前をクリックすると、その人の詳細ページへ遷移すること：https://gyazo.com/92579c62c38e35c1cb5e70250847b2ee
学生のマイページは、その学生本人にしか表示されないこと：https://gyazo.com/ade02b50ac89eb522d69fed9e19d3758
ユーザー詳細ページのコンテンツは新しい順に並んでいること：https://gyazo.com/19983acce13f85916e55809440280c90